### PR TITLE
fix: compile ts into js in production and modify import type

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Back-End Service for FreshGrade Application",
   "main": "index.js",
   "scripts": {
-    "start": "node src/app.ts",
+    "start": "node dist/app",
     "dev": "nodemon src/app.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
       "*": ["src/*"]                     /* Path mapping to resolve imports from the 'src' directory */
     },
     "outDir": "./dist",                  /* Redirect output structure to the directory */
+    "rootDir": "./src",
     "sourceMap": true,                    /* Generate corresponding '.map' file */
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
1. Now typescript files will compiled first into js files
2. Import type changed to `module`