### PR TITLE
fix: typo on cloud run service

### DIFF
--- a/.github/workflows/google-cloudrun-source.yml
+++ b/.github/workflows/google-cloudrun-source.yml
@@ -52,7 +52,7 @@ on:
 
 env:
   PROJECT_ID: freshgrade-bangkit # TODO: update Google Cloud project id
-  SERVICE: freshgrade-backed # TODO: update Cloud Run service name
+  SERVICE: freshgrade-backend # TODO: update Cloud Run service name
   REGION: asia-southeast2 # TODO: update Cloud Run service region
 
 jobs:


### PR DESCRIPTION
Before:

SERVICE_NAME = freshgrade-backed

After

SERVICE_NAME = freshgrade-backend