### PR TITLE
add description column on scan result

### DIFF
--- a/prisma/migrations/20240618140907_scan_2/migration.sql
+++ b/prisma/migrations/20240618140907_scan_2/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Scan" ADD COLUMN     "desc" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Scan {
   value    Float?
   disease  String?
   imageUrl String?
+  desc     String?
 
   createdById String?
   createdBy   User?   @relation(fields: [createdById], references: [id], onDelete: Cascade)

--- a/src/routes/scanner/scanner.service.ts
+++ b/src/routes/scanner/scanner.service.ts
@@ -138,13 +138,13 @@ const handleDiseasePrediction = (predictions: number[], fruit: string) => {
   let disease: string
   let description: string | null
 
-  // set threshold into 80%
+  // set threshold into 90%
   if (value * 100 > 90) {
     // match the disease with the fruit
     if (Math.floor(index/3) == FRUIT_INDEX[fruit]) {
       disease = CLASSIFICATION[index]
       description = DESCRIPTION[index]
-      
+
       return {
         disease,
         description


### PR DESCRIPTION
1. Add `description` column on scan result that contains description of the fruit disease
2. Set disease threshold into 90%
3. Match the predicted disease with predicted fruit